### PR TITLE
Bugfix fix find start row

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 npm-debug.log
 node_modules
+package-lock.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,45 @@
-language: objective-c
+### Project specific config ###
+language: generic
+
+env:
+  global:
+    - APM_TEST_PACKAGES=""
+    - ATOM_LINT_WITH_BUNDLED_NODE="true"
+
+  matrix:
+    - ATOM_CHANNEL=stable
+    - ATOM_CHANNEL=beta
+
+os:
+  - linux
+  - osx
+
+### Generic setup follows ###
+script:
+  - curl -s -O https://raw.githubusercontent.com/atom/ci/master/build-package.sh
+  - chmod u+x build-package.sh
+  - ./build-package.sh
 
 notifications:
   email:
     on_success: never
     on_failure: change
 
-script: 'curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh | sh'
+branches:
+  only:
+    - master
+
+git:
+  depth: 10
+
+sudo: false
+
+dist: trusty
+
+addons:
+  apt:
+    packages:
+    - build-essential
+    - fakeroot
+    - git
+    - libsecret-1-dev

--- a/README.md
+++ b/README.md
@@ -5,21 +5,45 @@
 YARD is a commonly used Ruby documentation tool. This package will accelerate
 the creation of the YARD-style comments for your methods and classes.
 
-### Usage
+## Usage
 
 To use it is as simple as situating on a method and pressing `ctrl + enter`.
-This will analyse the method params and generate the following snippet for the
-documentation:
+This will analyse the method (and its params), class, or module and generate the following type of documentation:
 
-```
-class UndocumentedClass
-  # Description of method
-  #
-  # @param [Type] param1 describe param1
-  # @param [Type] param2=3 describe param2=3
-  # @return [Type] description of returned object
-  def undocumented_method(param1, param2=3)
-    'The method is not documented!'
+```ruby
+# Description of UndocumentedModule
+module UndocumentedModule
+  # Description of UndocumentedClass
+  class UndocumentedClass
+
+    # Description of #undocumented_method
+    #
+    # @param [Type] param1 describe_param1
+    # @param [Type] param2 default: 3
+    # @param [Type] param4 default: { foo: :bar, baz: 'qux' }
+    # @return [Type] description_of_returned_object
+    def undocumented_method(param1, param2=3, param4 = { foo: :bar, baz: 'qux' })
+      'The method is not documented!'
+    end
+
+    # Description of #method_with_named_params
+    #
+    # @param [Type] param1 default: nil
+    # @param [Type] param2 default: true
+    # @param [Type] param3 default: nil
+    # @return [Type] description_of_returned_object
+    def method_with_named_params(param1:, param2: true, param3: nil)
+      'The method is not documented!'
+    end
+
+    # Description of .undocumented_method
+    #
+    # @param [Type] param1 describe_param1
+    # @param [Type] param2 default: 3
+    # @return [Type] description_of_returned_object
+    def self.undocumented_class_method(param1, param2=3)
+      'The method is not documented!'
+    end
   end
 end
 ```
@@ -27,8 +51,67 @@ end
 `Tab`/`shift + Tab` keys could be used to jump to the next param, description or
 Type.
 
-### Future
+# Planned Future Development
 
-I will update this package soon with more intelligence and features:
-* **Analyse better the method params.
-* **Implement for class.
+### • Add support for Hash params with `@options`
+
+```ruby
+# Description of #undocumented_method
+#
+# @param [Type] param1
+# @option [Type] foo default: nil
+# @option [Type] bar default: nil
+# @option [Type] baz default: nil
+# @return [Type] description_of_returned_object
+def undocumented_method(param1={ foo:, bar:, baz: })
+  'The method is not documented!'
+end
+```
+
+### • Implement for CONSTANTS:
+
+```ruby
+MY_CONSTANT = 'Important string'.freeze # Description of MY_CONSTANT
+```
+
+### • Add configuration for controlling spacing between lines
+
+Add comment above or below the description/`@param`/`@return` _(and possibly add a blank line above the comment)_
+
+```ruby
+module UndocumentedModule
+  class UndocumentedClass
+    def undocumented_method(param1, param2=3)
+      'The method is not documented!'
+    end
+  end
+end
+```
+
+to
+
+```ruby
+#
+# Description of UndocumentedModule
+#
+module UndocumentedModule
+
+  # Description of UndocumentedClass
+  #
+  class UndocumentedClass
+    # (this could be a blank line)
+    # Description of #undocumented_method
+    #
+    # @param [Type] param1 describe param1
+    #
+    # @param [Type] param2 default: 3
+    #
+    #
+    # @return [Type] description_of_returned_object
+    #
+    def undocumented_method(param1, param2=3)
+      'The method is not documented!'
+    end
+  end
+end
+```

--- a/README.md
+++ b/README.md
@@ -7,8 +7,11 @@ the creation of the YARD-style comments for your methods and classes.
 
 ## Usage
 
-To use it is as simple as situating on a method and pressing `ctrl + enter`.
-This will analyse the method (and its params), class, or module and generate the following type of documentation:
+To use it is as simple as moving the cursor below something that needs documentation and pressing `ctrl + enter`.
+
+###### In many cases, this will be the body of a method, but if the cursor is above the topmost method it will search for the next, constant, class, or module.
+
+This will analyse the method (and its params), class, constant, or module and generate the following type of documentation:
 
 ```ruby
 # Description of UndocumentedModule
@@ -52,7 +55,17 @@ end
 `Tab`/`shift + Tab` keys could be used to jump to the next param, description or
 Type.
 
-### Configuration
+#### Snippets
+
+| Type This then Tab | Produces This                                                                                                      |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------ |
+| #@E                | `#\n# @example example here\n#`                                                                                    |
+| #@O                | `# @option parent [Type] argument definition`                                                                      |
+| #@P                | `# @param [Type] param_name describe_param_here`                                                                   |
+| #@H                | `# @param [Type] argument# @option parent [Type] argument definition\n# @option parent [Type] argument definition` |
+| #@R                | `# @return [Type] definition`                                                                                      |
+
+## Configuration
 
 Through configuration settings you can add a blank comment line above or below the
 description, `@param`s, and `@return`, as well as ensure there is a blank line
@@ -68,7 +81,25 @@ module UndocumentedModule
 end
 ```
 
-to
+with minimal spacing changes to (everything set to false):
+
+```ruby
+# Description of UndocumentedModule
+module UndocumentedModule
+  # Description of UndocumentedClass
+  class UndocumentedClass
+    # Description of #undocumented_method
+    # @param [Type] param1 describe param1
+    # @param [Type] param2 default: 3
+    # @return [Type] description_of_returned_object
+    def undocumented_method(param1, param2=3)
+      'The method is not documented!'
+    end
+  end
+end
+```
+
+with maximum spacing changes to(everything set to true):
 
 ```ruby
 #
@@ -76,13 +107,17 @@ to
 #
 module UndocumentedModule
 
+  #
   # Description of UndocumentedClass
   #
   class UndocumentedClass
-    # (this could be a blank line)
+
+    #
     # Description of #undocumented_method
     #
+    #
     # @param [Type] param1 describe param1
+    #
     #
     # @param [Type] param2 default: 3
     #
@@ -96,9 +131,11 @@ module UndocumentedModule
 end
 ```
 
+and any combination in between.
+
 # Planned Future Development
 
-### • Add support for Hash params with `@options`
+### • Add support for interpreting Hash params with `@options`
 
 ```ruby
 # Description of #undocumented_method

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This will analyse the method (and its params), class, or module and generate the
 module UndocumentedModule
   # Description of UndocumentedClass
   class UndocumentedClass
+    MY_CONSTANT = 'Important string'.freeze # Description of MY_CONSTANT
 
     # Description of #undocumented_method
     #
@@ -66,12 +67,6 @@ Type.
 def undocumented_method(param1={ foo:, bar:, baz: })
   'The method is not documented!'
 end
-```
-
-### • Implement for CONSTANTS:
-
-```ruby
-MY_CONSTANT = 'Important string'.freeze # Description of MY_CONSTANT
 ```
 
 ### • Add configuration for controlling spacing between lines

--- a/README.md
+++ b/README.md
@@ -52,26 +52,11 @@ end
 `Tab`/`shift + Tab` keys could be used to jump to the next param, description or
 Type.
 
-# Planned Future Development
+### Configuration
 
-### • Add support for Hash params with `@options`
-
-```ruby
-# Description of #undocumented_method
-#
-# @param [Type] param1
-# @option [Type] foo default: nil
-# @option [Type] bar default: nil
-# @option [Type] baz default: nil
-# @return [Type] description_of_returned_object
-def undocumented_method(param1={ foo:, bar:, baz: })
-  'The method is not documented!'
-end
-```
-
-### • Add configuration for controlling spacing between lines
-
-Add comment above or below the description/`@param`/`@return` _(and possibly add a blank line above the comment)_
+Through configuration settings you can add a blank comment line above or below the
+description, `@param`s, and `@return`, as well as ensure there is a blank line
+above the generated comment.
 
 ```ruby
 module UndocumentedModule
@@ -108,5 +93,22 @@ module UndocumentedModule
       'The method is not documented!'
     end
   end
+end
+```
+
+# Planned Future Development
+
+### • Add support for Hash params with `@options`
+
+```ruby
+# Description of #undocumented_method
+#
+# @param [Type] param1
+# @option [Type] foo default: nil
+# @option [Type] bar default: nil
+# @option [Type] baz default: nil
+# @return [Type] description_of_returned_object
+def undocumented_method(param1={ foo:, bar:, baz: })
+  'The method is not documented!'
 end
 ```

--- a/lib/snippets/yard.cson
+++ b/lib/snippets/yard.cson
@@ -10,9 +10,11 @@
     body: '# @param [${1:Type}] ${2:param_name} ${3:describe_param_here}'
   'YARD @param [Hash] with @options':
     prefix: '#@H'
-    body: "# @param [${1:Type}] ${2:argument}" +
-    "\n# @option ${2:parent} [${3:Type}] ${4:argument} ${5:definition}" +
-    "\n# @option ${2:parent} [${6:Type}] ${7:argument} ${8:definition}"
+    body: """
+      # @param [${1:Type}] ${2:argument}
+      # @option ${2:parent} [${3:Type}] ${4:argument} ${5:definition}
+      # @option ${2:parent} [${6:Type}] ${7:argument} ${8:definition}
+    """
   'YARD @return':
     prefix: '#@R'
     body: '# @return [${1:Type}] ${2:definition}'

--- a/lib/yard.coffee
+++ b/lib/yard.coffee
@@ -11,23 +11,31 @@ module.exports = Yard =
     editor.transact =>
       row = @parseStartRow(editor, cursor)
       if !row.type or @commentAlreadyExists(editor, row) then return
-
       comment = @buildComment(row)
-      @insertSnippet(editor, cursor, row.number, comment)
+      @insertSnippet(editor, cursor, row.number, comment, (row.type isnt 'constant'))
 
   parseStartRow: (editor, cursor) ->
     row = { name: '', number: 0, params: '', type: '' }
     editor.moveToEndOfLine()
     scanStart = cursor.getBufferPosition()
     endScan = [0,0]
-    # TODO: add CONSTANTS RexExp /[A-Z_]+\s*=/
-    regExp = /(def|class|module)\s(self)?\.?(\w+)(\(.*\))?/
+    regExp = ///
+      (def|class|module|[A-Z_]+\s*=) # [1] determines what is being defined
+      \s+                            # spaces between keyword and name
+      (self)?                        # [2] determines whether or not it's a class_method
+      \.?                            # period that exists for class_method
+      (\w+)?                         # [3] class, method, or module name
+      (\(.*\))?                      # [4] params
+    ///
     editor.backwardsScanInBufferRange regExp, [scanStart, endScan], (element) =>
       row.params = element.match[4]
       row.number = element.range.end.row
       if element.match[1] is 'def'
         row.name = "#{if element.match[2] is 'self' then '.' else '#'}" + element.match[3]
         row.type = "#{if element.match[2] is 'self' then 'class_' else ''}method"
+      else if element.match[1].match /[A-Z_]+\s*=/
+        row.name = element.match[1].replace('=', '').trim()
+        row.type = 'constant'
       else
         row.name = element.match[3]
         row.type = element.match[1]
@@ -35,21 +43,25 @@ module.exports = Yard =
     row
 
   commentAlreadyExists: (editor, row) ->
-    if row.number is 0
-      return false
-    else
-      rowAbove = editor.lineTextForBufferRow(row.number - 1)
-      if row.type.match(/method/)
-        !!(rowAbove.match(/# @return/))
-      else
-        !!(rowAbove.match(/# /))
+    if row.number is 0 then return false
+    if row.type is 'constant' then return editor.lineTextForBufferRow(row.number).match(/# /)
 
-  insertSnippet: (editor, cursor, definitionRowNumber, comment) ->
+    rowAbove = editor.lineTextForBufferRow(row.number - 1)
+    if row.type.match(/method/)
+      rowAbove.match(/# @return/)
+    else
+      rowAbove.match(/# /)
+
+  insertSnippet: (editor, cursor, definitionRowNumber, comment, printAbove) ->
     cursor.setBufferPosition([definitionRowNumber, 0])
     editor.moveToFirstCharacterOfLine()
     indentation = cursor.getIndentLevel()
-    editor.insertNewlineAbove()
-    editor.setIndentationForBufferRow(cursor.getBufferRow(), indentation)
+    if printAbove
+      editor.insertNewlineAbove()
+      editor.setIndentationForBufferRow(cursor.getBufferRow(), indentation)
+    else
+      editor.moveToEndOfLine()
+      comment = ' ' + comment
     Snippets.insert(comment)
 
   buildComment: (row) ->

--- a/lib/yard.coffee
+++ b/lib/yard.coffee
@@ -20,13 +20,14 @@ module.exports = Yard =
     editor.moveToEndOfLine()
     scanStart = cursor.getBufferPosition()
     endScan = [0,0]
-    regExp = /(def|class|module)\s(self)?(.?\w+)(\(.*\))?/
+    # TODO: add CONSTANTS RexExp /[A-Z_]+\s*=/
+    regExp = /(def|class|module)\s(self)?\.?(\w+)(\(.*\))?/
     editor.backwardsScanInBufferRange regExp, [scanStart, endScan], (element) =>
       row.params = element.match[4]
       row.number = element.range.end.row
       if element.match[1] is 'def'
-        row.name = if element.match[2] is 'self' then element.match[3] else '#' + element.match[3]
-        row.type = "#{if element.match[2] is 'self' then 'class ' else ''}method"
+        row.name = "#{if element.match[2] is 'self' then '.' else '#'}" + element.match[3]
+        row.type = "#{if element.match[2] is 'self' then 'class_' else ''}method"
       else
         row.name = element.match[3]
         row.type = element.match[1]

--- a/lib/yard.coffee
+++ b/lib/yard.coffee
@@ -132,7 +132,7 @@ module.exports = Yard =
       default: true
     ensureBlankLineBeforeDescription:
       type: 'boolean'
-      default: true
+      default: false
     addCommentLineBeforeDescription:
       type: 'boolean'
       default: false

--- a/lib/yard.coffee
+++ b/lib/yard.coffee
@@ -15,10 +15,15 @@ module.exports = Yard =
       @insertSnippet(editor, cursor, prevDefRow, snippet_string)
 
   findStartRow: (editor, cursor) ->
-    row = cursor.getBufferRow()
-    while (editor.buffer.lines[row].indexOf('def ') == -1)
-      break if row == 0
-      row -= 1
+    row = 0
+    editor.moveToEndOfLine()
+    scanStart = cursor.getBufferPosition()
+    endScan = [0,0]
+
+    editor.backwardsScanInBufferRange /(def)\s/, [scanStart, endScan], (element) =>
+      row = element.range.end.row
+      element.stop()
+
     row
 
   insertSnippet: (editor, cursor, prevDefRow, snippet_string) ->

--- a/lib/yard.coffee
+++ b/lib/yard.coffee
@@ -74,4 +74,4 @@ module.exports = Yard =
     paramsArray = paramString.replace(/\(|\)/g, '').split(',')
     for param in paramsArray
       paramMatch = param.match /(\w+)\s*([=:])?\s*(.+)?/
-      { argument: paramMatch[1], default: paramMatch[2] && paramMatch[3] }
+      { argument: paramMatch[1], default: paramMatch[2] && (paramMatch[3] || 'nil') }

--- a/lib/yard.coffee
+++ b/lib/yard.coffee
@@ -12,7 +12,10 @@ module.exports = Yard =
     addCommentLineBeforeDescription:
       type: 'boolean'
       default: false
-    addCommentLineAfterDescription:
+    addCommentLineAfterClassOrModuleDescription:
+      type: 'boolean'
+      default: false
+    addCommentLineAfterMethodDescription:
       type: 'boolean'
       default: true
     addCommentLineBeforeParams:
@@ -90,24 +93,29 @@ module.exports = Yard =
   buildComment: (editor, row) ->
     params = @buildParams(row.params)
     comment = ''
-    if atom.config.get('yard.ensureBlankLineBeforeDescription')
+    if row.number isnt 0 and row.type isnt 'constant' and atom.config.get('yard.ensureBlankLineBeforeDescription')
       if editor.lineTextForBufferRow(row.number - 1).trim().length isnt 0
         comment += "\n"
     if atom.config.get('yard.addCommentLineBeforeDescription') then comment += "\n#"
+    # Description
     comment += "# ${1:Description of #{row.name}}"
-    if atom.config.get('yard.addCommentLineAfterDescription') then comment += "\n#"
+
+    if row.type.match /(class|module)/
+      if atom.config.get('yard.addCommentLineAfterClassOrModuleDescription') then comment += "\n#"
     if row.type.match /method/
+      if atom.config.get('yard.addCommentLineAfterMethodDescription') then comment += "\n#"
       index = 1
       for param in params
         if atom.config.get('yard.addCommentLineBeforeParams') then comment += "\n#"
+        # @param
         comment += "\n# @param [${#{index+=1}:Type}] #{param.argument} "
-        postfix = if param.default
-          "default: #{param.default}"
-        else
-          "describe_#{param.argument}_here"
+        postfix = if param.default then "default: #{param.default}" else "describe_#{param.argument}_here"
         comment += "${#{index+=1}:#{postfix}}"
+
         if atom.config.get('yard.addCommentLineAfterParams') then comment += "\n#"
       if atom.config.get('yard.addCommentLineBeforeReturn') then comment += "\n#"
+
+      # @return
       comment += "\n# @return [${#{index+=1}:Type}] ${#{index+1}:description_of_returned_object}"
 
     comment

--- a/menus/yard.cson
+++ b/menus/yard.cson
@@ -10,10 +10,10 @@
   {
     'label': 'Packages'
     'submenu': [
-      'label': 'yard'
+      'label': 'Yard'
       'submenu': [
         {
-          'label': 'Create YARD'
+          'label': 'Generate Documentation'
           'command': 'yard:create'
         }
       ]

--- a/snippets/yard.cson
+++ b/snippets/yard.cson
@@ -1,10 +1,18 @@
 '.source.ruby':
+  'YARD @example':
+    prefix: '#@E'
+    body: "#\n# @example ${1:example here}\n#"
   'YARD @option':
-    prefix: '#@o'
+    prefix: '#@O'
     body: '# @option ${1:parent} [${2:Type}] ${3:argument} ${4:definition}'
   'YARD @param':
-    prefix: '#@p'
-    body: '# @param [${1:Type}] ${2:argument} ${3:definition}'
+    prefix: '#@P'
+    body: '# @param [${1:Type}] ${2:param_name} ${3:describe_param_here}'
+  'YARD @param [Hash] with @options':
+    prefix: '#@H'
+    body: "# @param [${1:Type}] ${2:argument}" +
+    "\n# @option ${2:parent} [${3:Type}] ${4:argument} ${5:definition}" +
+    "\n# @option ${2:parent} [${6:Type}] ${7:argument} ${8:definition}"
   'YARD @return':
-    prefix: '#@r'
-    body: '# @return [${1:Type}] ${3:definition}'
+    prefix: '#@R'
+    body: '# @return [${1:Type}] ${2:definition}'

--- a/snippets/yard.cson
+++ b/snippets/yard.cson
@@ -1,0 +1,10 @@
+'.source.ruby':
+  'YARD @option':
+    prefix: '#@o'
+    body: '# @option ${1:parent} [${2:Type}] ${3:argument} ${4:definition}'
+  'YARD @param':
+    prefix: '#@p'
+    body: '# @param [${1:Type}] ${2:argument} ${3:definition}'
+  'YARD @return':
+    prefix: '#@r'
+    body: '# @return [${1:Type}] ${3:definition}'

--- a/spec/yard-spec.coffee
+++ b/spec/yard-spec.coffee
@@ -30,7 +30,7 @@ describe "Yard", ->
           editor.getLastCursor().setBufferPosition([1,0])
           atom.commands.dispatch workspaceElement, 'yard:create'
 
-        it "writes a default YARD doc", ->
+        it "does nothing", ->
           expected_output = """
             class UndocumentedClass
               CONSTANT = 1 # This can be anything
@@ -58,7 +58,7 @@ describe "Yard", ->
           editor.getLastCursor().setBufferPosition([0,0])
           atom.commands.dispatch workspaceElement, 'yard:create'
 
-        it "writes a default YARD doc", ->
+        it "does nothing", ->
           expected_output = """
             # This can be anything
             class UndocumentedClass
@@ -112,7 +112,7 @@ describe "Yard", ->
             editor.getLastCursor().setBufferPosition([3,0])
             atom.commands.dispatch workspaceElement, 'yard:create'
 
-          it "inserts a default YARD doc", ->
+          it "inserts a default YARD doc between the comment and the definition", ->
             expected_output = """
               class UndocumentedClass
                 # Any comment
@@ -145,7 +145,7 @@ describe "Yard", ->
         editor.getLastCursor().setBufferPosition([1,0])
         atom.commands.dispatch workspaceElement, 'yard:create'
 
-      it "writes a default YARD doc", ->
+      it "writes an inline YARD doc", ->
         expected_output = """
           class UndocumentedClass
             FANCY_CONSTANT = :foo # Description of FANCY_CONSTANT
@@ -172,7 +172,7 @@ describe "Yard", ->
         editor.getLastCursor().setBufferPosition([0,0])
         atom.commands.dispatch workspaceElement, 'yard:create'
 
-      it "writes a default YARD doc", ->
+      it "writes YARD doc description", ->
         expected_output = """
           # Description of UndocumentedClass
           class UndocumentedClass
@@ -201,7 +201,7 @@ describe "Yard", ->
         editor.getLastCursor().setBufferPosition([0,0])
         atom.commands.dispatch workspaceElement, 'yard:create'
 
-      it "writes a default YARD doc", ->
+      it "writes YARD doc description", ->
         expected_output = """
           # Description of UndocumentedModule
           module UndocumentedModule

--- a/spec/yard-spec.coffee
+++ b/spec/yard-spec.coffee
@@ -24,23 +24,23 @@ describe "Yard", ->
               'The method is not documented!'
             end
           end
-
         """
         editor.getLastCursor().setBufferPosition([2,0])
         atom.commands.dispatch workspaceElement, 'yard:create'
 
       it "writes a default YARD doc", ->
-        expected_output = """class UndocumentedClass
-                               # Description of method
-                               #
-                               # @param [Type] param1 describe param1
-                               # @param [Type] param2=3 describe param2=3
-                               # @return [Type] description of returned object
-                               def undocumented_method(param1, param2=3)
-                                 'The method is not documented!'
-                               end
-                             end
-                             """
+        expected_output = """
+          class UndocumentedClass
+            # Description of #undocumented_method
+            #
+            # @param [Type] param1 describe_param1_here
+            # @param [Type] param2 default: 3
+            # @return [Type] description_of_returned_object
+            def undocumented_method(param1, param2=3)
+              'The method is not documented!'
+            end
+          end
+        """
         output = buffer.getText()
         expect(output).toContain(expected_output)
 
@@ -57,25 +57,25 @@ describe "Yard", ->
               'Noooot documented!!!'
             end
           end
-
         """
         editor.getLastCursor().setBufferPosition([4,0])
         atom.commands.dispatch workspaceElement, 'yard:create'
 
       it "writes a default YARD doc", ->
-        expected_output = """class UndocumentedClass
-                               # Description of method
-                               #
-                               # @param [Type] param1 describe param1
-                               # @param [Type] param2 = 3 describe param2 = 3
-                               # @param [Type] opts = {} describe opts = {}
-                               # @return [Type] description of returned object
-                               def undocumented_multiline_method(param1, param2 = 3, opts = {})
-                                 'Not documented!'
-                                 'Noot documented!'
-                                 'Noooot documented!!!'
-                               end
-                             end
-                             """
+        expected_output = """
+          class UndocumentedClass
+            # Description of #undocumented_multiline_method
+            #
+            # @param [Type] param1 describe_param1_here
+            # @param [Type] param2 default: 3
+            # @param [Type] opts default: {}
+            # @return [Type] description_of_returned_object
+            def undocumented_multiline_method(param1, param2 = 3, opts = {})
+              'Not documented!'
+              'Noot documented!'
+              'Noooot documented!!!'
+            end
+          end
+        """
         output = buffer.getText()
         expect(output).toContain(expected_output)

--- a/spec/yard-spec.coffee
+++ b/spec/yard-spec.coffee
@@ -13,7 +13,35 @@ describe "Yard", ->
         buffer = editor.buffer
 
   describe "when the yard:create event is triggered", ->
-    describe "for single line method", ->
+    describe "for a constant", ->
+      beforeEach ->
+        waitsForPromise ->
+          activationPromise
+
+        editor.insertText """
+          class UndocumentedClass
+            FANCY_CONSTANT = :foo
+            def undocumented_method(param1, param2=3)
+              'The method is not documented!'
+            end
+          end
+        """
+        editor.getLastCursor().setBufferPosition([1,0])
+        atom.commands.dispatch workspaceElement, 'yard:create'
+
+      it "writes a default YARD doc", ->
+        expected_output = """
+          class UndocumentedClass
+            FANCY_CONSTANT = :foo # Description of FANCY_CONSTANT
+            def undocumented_method(param1, param2=3)
+              'The method is not documented!'
+            end
+          end
+        """
+        output = buffer.getText()
+        expect(output).toContain(expected_output)
+
+    describe "for a class", ->
       beforeEach ->
         waitsForPromise ->
           activationPromise
@@ -25,18 +53,76 @@ describe "Yard", ->
             end
           end
         """
+        editor.getLastCursor().setBufferPosition([0,0])
+        atom.commands.dispatch workspaceElement, 'yard:create'
+
+      it "writes a default YARD doc", ->
+        expected_output = """
+          # Description of UndocumentedClass
+          class UndocumentedClass
+            def undocumented_method(param1, param2=3)
+              'The method is not documented!'
+            end
+          end
+        """
+        output = buffer.getText()
+        expect(output).toContain(expected_output)
+
+    describe "for a module", ->
+      beforeEach ->
+        waitsForPromise ->
+          activationPromise
+
+        editor.insertText """
+          module UndocumentedModule
+            class UndocumentedClass
+              def undocumented_method(param1, param2=3)
+                'The method is not documented!'
+              end
+            end
+          end
+        """
+        editor.getLastCursor().setBufferPosition([0,0])
+        atom.commands.dispatch workspaceElement, 'yard:create'
+
+      it "writes a default YARD doc", ->
+        expected_output = """
+          # Description of UndocumentedModule
+          module UndocumentedModule
+            class UndocumentedClass
+              def undocumented_method(param1, param2=3)
+                'The method is not documented!'
+              end
+            end
+          end
+        """
+        output = buffer.getText()
+        expect(output).toContain(expected_output)
+
+    describe "for class method", ->
+      beforeEach ->
+        waitsForPromise ->
+          activationPromise
+
+        editor.insertText """
+          class UndocumentedClass
+            def self.undocumented_method(param1, param2=3)
+              'The method is not documented!'
+            end
+          end
+        """
         editor.getLastCursor().setBufferPosition([2,0])
         atom.commands.dispatch workspaceElement, 'yard:create'
 
       it "writes a default YARD doc", ->
         expected_output = """
           class UndocumentedClass
-            # Description of #undocumented_method
+            # Description of .undocumented_method
             #
             # @param [Type] param1 describe_param1_here
             # @param [Type] param2 default: 3
             # @return [Type] description_of_returned_object
-            def undocumented_method(param1, param2=3)
+            def self.undocumented_method(param1, param2=3)
               'The method is not documented!'
             end
           end
@@ -79,3 +165,52 @@ describe "Yard", ->
         """
         output = buffer.getText()
         expect(output).toContain(expected_output)
+
+  # (Is it a feature or a bug? You decide)
+  describe "when the yard:create event is triggered multiple times, from the bottom of the page", ->
+    beforeEach ->
+      waitsForPromise ->
+        activationPromise
+
+      editor.insertText """
+        class UndocumentedClass
+
+          def undocumented_method(param1, param2=3)
+            'The method is not documented!'
+          end
+
+          def another_undocumented_method(param1)
+            'The method is not documented!'
+          end
+        end
+      """
+      editor.getLastCursor().setBufferPosition([10,0])
+      atom.commands.dispatch workspaceElement, 'yard:create'
+      atom.commands.dispatch workspaceElement, 'yard:create'
+      atom.commands.dispatch workspaceElement, 'yard:create'
+
+    it "writes a default YARD doc", ->
+      expected_output = """
+        # Description of UndocumentedClass
+        class UndocumentedClass
+
+          # Description of #undocumented_method
+          #
+          # @param [Type] param1 describe_param1_here
+          # @param [Type] param2 default: 3
+          # @return [Type] description_of_returned_object
+          def undocumented_method(param1, param2=3)
+            'The method is not documented!'
+          end
+
+          # Description of #another_undocumented_method
+          #
+          # @param [Type] param1 describe_param1_here
+          # @return [Type] description_of_returned_object
+          def another_undocumented_method(param1)
+            'The method is not documented!'
+          end
+        end
+      """
+      output = buffer.getText()
+      expect(output).toContain(expected_output)


### PR DESCRIPTION
## Description
This started as a bug fix, for a syntax change, but grew into a general development branch once I got things working.

## Things that have changed
* BugFix: change `while()` conditional to `TextEditor.backwardsScanInBufferRange()` to fetch row number
* `number`, `type`, and `name` are parsed from the row
* Editor checks for existing comment before adding new comment
* Method name arguments, including defaults, are parsed
* Configuration is added for spacing and positioning of comments
• Snippets are added for one off comment lines (i.e. `# @option`)